### PR TITLE
Add installation of pip metadata files for when casadi python bindings are installed only via CMake

### DIFF
--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -162,6 +162,30 @@ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/__init__.py
   COMPONENT install_python
 )
 
+# Install pip metadata files to ensure that CMake install are listed by pip list
+# See https://packaging.python.org/specifications/recording-installed-packages/
+# and https://packaging.python.org/en/latest/specifications/core-metadata/#core-metadata
+option(CASADI_PYTHON_PIP_METADATA_INSTALL "Use CMake to install Python pip metadata. Set to false if some other tool installs it." TRUE)
+mark_as_advanced(CASADI_PYTHON_PIP_METADATA_INSTALL)
+set(CASADI_PYTHON_PIP_METADATA_INSTALLER "cmake" CACHE STRING "Specify the string to identify the pip Installer. Default: cmake, change this if you are using another tool.")
+mark_as_advanced(CASADI_PYTHON_PIP_METADATA_INSTALLER)
+if (CASADI_PYTHON_PIP_METADATA_INSTALL)
+  if (WIN32)
+    set(NEW_LINE "\n\r")
+  else()
+    set(NEW_LINE "\n")
+  endif()
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/METADATA "")
+  file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/METADATA "Metadata-Version: 2.1${NEW_LINE}")
+  file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/METADATA "Name: casadi${NEW_LINE}")
+  file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/METADATA "Version: ${CASADI_VERSION}${NEW_LINE}")
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/INSTALLER "${CASADI_PYTHON_PIP_METADATA_INSTALLER}${NEW_LINE}")
+  install(
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/METADATA" "${CMAKE_CURRENT_BINARY_DIR}/INSTALLER"
+    DESTINATION ${PYTHON_PREFIX}/casadi-${CASADI_VERSION}.dist-info
+    COMPONENT install_python)
+endif()
+
 # Example of how to extend CasADi with additional features
 if (WITH_EXTENDING_CASADI)
   set_source_files_properties(../extending_casadi/extending_casadi.i  PROPERTIES  CPLUSPLUS ON)


### PR DESCRIPTION
When `casadi` is installed only via CMake by enabling the `WITH_PYTHON` and then the python installation directory is added in `PYTHONPATH`, the casadi library is not listed by `pip list` .
This is not problematic until a user tries to install a Python library that depends on `casadi` via  `pip install .` . In that case, the Python `casadi` package already available in the system is ignored, and the PyPI version of casadi is installed itself. 

This PR adds the CMake logic to generate the necessary `METADATA` and `INSTALLER` Python files so that even when just installed via cmake, the `casadi` python package can be listed by `pip list` .
This logic can be disabled by a dedicated option. 