### PR TITLE
Do not define proxsuite::proxsuite as IMPORTED target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1458,7 +1458,7 @@ if(WITH_PROXQP)
         # --debug-find
     add_library(proxqp INTERFACE)
     # This is similar to ALIAS but works fine on imported targets with CMake 3.10
-    add_library(proxsuite::proxsuite INTERFACE IMPORTED)
+    add_library(proxsuite::proxsuite INTERFACE)
     set_target_properties(proxsuite::proxsuite PROPERTIES INTERFACE_LINK_LIBRARIES proxqp)
     add_dependencies(proxqp proxqp-external)
     target_include_directories(proxqp INTERFACE "${CMAKE_BINARY_DIR}/external_projects/include")


### PR DESCRIPTION
Without this change, some of the CI jobs fail with error:
~~~
-- Configuring done
CMake Error in casadi/interfaces/proxqp/CMakeLists.txt:
  Imported target "proxsuite::proxsuite" includes non-existent path

    "/work/build/external_projects/include/eigen3"

  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:

  * The path was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and references files it does not
  provide.
~~~